### PR TITLE
Some convenience improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ type Holiday struct {
 			Day   int `json:"day"`
 		} `json:"datetime"`
 	} `json:"date"`
+	GoDate    time.Time   `json:"-"` // This field is not in the original response, so ignore it when parsing JSON
 	Type      []string    `json:"type"`
 	Locations string      `json:"locations"`
 	States    interface{} `json:"states"` // sometimes its a struct, sometime its a string, so use interface
@@ -102,6 +103,11 @@ func (p *CalParameters) requestHandler() (*CalResponse, error) {
 	err = json.Unmarshal(contents, &c)
 	if err != nil {
 		return c, fmt.Errorf("received error when unmarshalling the data, error: %v", err)
+	}
+	for i, h := range c.Response.Holidays {
+		dt := h.Date.Datetime
+		h.GoDate = time.Date(dt.Year, time.Month(dt.Month), dt.Day, 0, 0, 0, 0, time.Local)
+		c.Response.Holidays[i] = h
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -33,22 +33,24 @@ type CalResponse struct {
 		Code int `json:"code"`
 	} `json:"meta"`
 	Response struct {
-		Holidays []struct {
-			Name        string `json:"name"`
-			Description string `json:"description"`
-			Date        struct {
-				Iso      string `json:"iso"`
-				Datetime struct {
-					Year  int `json:"year"`
-					Month int `json:"month"`
-					Day   int `json:"day"`
-				} `json:"datetime"`
-			} `json:"date"`
-			Type      []string    `json:"type"`
-			Locations string      `json:"locations"`
-			States    interface{} `json:"states"` // sometimes its a struct, sometime its a string, so use interface
-		} `json:"holidays"`
+		Holidays []Holiday `json:"holidays"`
 	} `json:"response"`
+}
+
+type Holiday struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Date        struct {
+		Iso      string `json:"iso"`
+		Datetime struct {
+			Year  int `json:"year"`
+			Month int `json:"month"`
+			Day   int `json:"day"`
+		} `json:"datetime"`
+	} `json:"date"`
+	Type      []string    `json:"type"`
+	Locations string      `json:"locations"`
+	States    interface{} `json:"states"` // sometimes its a struct, sometime its a string, so use interface
 }
 
 // We don't use this struct, since the states response json is not always a JSON


### PR DESCRIPTION
Thanks for this project. It is nice to not have to write Http requests, but to have a convenient way to interface with the API.

I have made two improvements to make the library a little more convenient:
- I separated the Holiday struct into it's own type, this better leverages Go's static typing. It is nice to able to work with a Holiday struct, as that is the most meaningful data coming from the API.
- I added a field to the Holiday struct called GoDate. This field contains the holiday's date in the native `time.Time` type, which is convenient to work with.

I know it's bad form to add two features in one PR, but I figured this repo is small enough